### PR TITLE
fix events

### DIFF
--- a/lua/witt/init.lua
+++ b/lua/witt/init.lua
@@ -87,7 +87,7 @@ vim.api.nvim_create_user_command(
 )
 vim.api.nvim_create_user_command("WittClear", M.clear, { desc = "Remove the Witt Annotations" })
 
-vim.api.nvim_create_autocmd({ "TextChanged" }, {
+vim.api.nvim_create_autocmd({ "TextChanged", "InsertLeave" }, {
 	pattern = "*.ts,*.tsx,*.mts",
 	callback = M.update_diagnostics,
 })

--- a/lua/witt/init.lua
+++ b/lua/witt/init.lua
@@ -51,6 +51,11 @@ function M.update_diagnostics()
 	local annotations = find_annotations()
 	local diagnostics = {}
 
+	if #annotations == 0 then
+		vim.diagnostic.set(M.namespace, bufnr, {}, { signs = false })
+		return
+	end
+
 	for _, annotation in ipairs(annotations) do
 		local params = {
 			textDocument = vim.lsp.util.make_text_document_params(),


### PR DESCRIPTION
- **fix(last diagnotic): remove when none**
- **fix(autocmd): update on InsertLeave**

This makes the `^?` operation work more reliably. There was some issues with insert mode not updating the diagnostics because `TextChanged` does not trigger while in insert mode. The last diagnostic fix was hard to demonstrate with an example, but it makes sense when you see that the for loop does not run when there is no diagnostics.

Here is demo of before vs after. I could not figure out how to demonstrate the last diagnostic fix, but I have defninitely seen this happen where diagnostics linger when there is just one:
https://github.com/user-attachments/assets/d18cac49-4936-40de-9c6e-b9127c7c459f

